### PR TITLE
Add KaTex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .env.development.local
 .env.test.local
 .env.production.local
+*.xml

--- a/.idea/project-synesthesia-reading-app.iml
+++ b/.idea/project-synesthesia-reading-app.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -2,8 +2,8 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 
-const { default: remarkMath } = require('remark-math');
-const {default: rehypeKatex} = require('rehype-katex')
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 
 // const lightCodeTheme = require('prism-react-renderer/themes/github');
 // const darkCodeTheme = require('prism-react-renderer/themes/dracula');

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -1,6 +1,10 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+
+const { default: remarkMath } = require('remark-math');
+const {default: rehypeKatex} = require('rehype-katex')
+
 // const lightCodeTheme = require('prism-react-renderer/themes/github');
 // const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
@@ -23,6 +27,7 @@ const main_template_jira_scripts = () => {
 const title = ''+process.env.PROJECT_NAME.replaceAll('-',' ').split(' ').map((word) => {
   return word[0].toUpperCase() + word.substring(1);
 }).join(' ');
+
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -63,6 +68,8 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: 'docs',
           path: 'docs',
+          remarkPlugins: [remarkMath],
+          rehypePlugins: [rehypeKatex],
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:


### PR DESCRIPTION
@ApplebaumIan I _think_ this should enable LaTex formatting, if you also install the remark-math and rehype-katex plugins to the docusaurus server, as seen [here](https://docusaurus.io/docs/markdown-features/math-equations). If you're amenable, it would be nice to be able to do that on the documentation website.